### PR TITLE
Feature/replace old converters

### DIFF
--- a/src/converterHandler.ts
+++ b/src/converterHandler.ts
@@ -7,7 +7,7 @@ import { FILE_NAME_HEADER, RESOLVED_TIMESTAMP_FORMAT, RESOLVED_TIMESTAMP_HEADER 
 export class ConversionHandler {
 	private metaDataCache: Map<string, [number, FileMetaData]>;
 
-	private converters: {[s: string]: FTracyConverter<string | ReadStream>};
+	private converters: {[s: string]: FTracyConverter<string> | FTracyConverter<ReadStream>};
 
 	private fileLastModChecker: (s: string) => number;
 
@@ -33,7 +33,7 @@ export class ConversionHandler {
 	 * @param name The name to display to the user.
 	 * @param converterFunction The converter function.
 	 */
-	public addConverter(name: string, converterFunction: FTracyConverter<string | ReadStream>) {
+	public addConverter(name: string, converterFunction: FTracyConverter<string> | FTracyConverter<ReadStream>) {
 		this.converters[name] = converterFunction;
 	}
 
@@ -79,8 +79,9 @@ export class ConversionHandler {
 			const cached = this.getCachedMetadata(fileName, converters[index], options);
 			if (cached) return Promise.resolve(cached);
 
-			return this.converters[converters[index]].getMetadata(fileName, options)
-			.then(fmd => {
+			const converter = this.converters[converters[index]];
+			return converter.fileReader(fileName).then(fileData => converter.getMetadata(fileData as never, options)).then(fmd => {
+				fmd.fileName = fileName;
 				// Add extra errors/Filter output
 				if (fmd.headers.length <= 1) return Promise.reject("Insufficient headers. Wrong format?");
 				if (parseDateString(fmd.headers[TIMESTAMP_HEADER_INDEX]).isValid()) return Promise.reject("First header seems to be a timestamp. Does the input have headers?");
@@ -101,7 +102,8 @@ export class ConversionHandler {
 	 */
 	public getConversion(fileNames: string[], converters: string[], constraints: [string, string]): Promise<PromiseSettledResult<TracyData[]>[]> {
 		return Promise.allSettled(fileNames.map((fileName, index) => {
-			return this.converters[converters[index]].getData(fileName, constraints).then(arr => arr.map(v => {
+			const converter = this.converters[converters[index]];
+			return converter.fileReader(fileName).then(fileData => converter.getData(fileData as never, constraints)).then(arr => arr.map(v => {
 				// add file name to output
 				v[FILE_NAME_HEADER] = fileName;
 				// add resolved timestamps

--- a/src/converterHandler.ts
+++ b/src/converterHandler.ts
@@ -31,10 +31,19 @@ export class ConversionHandler {
 	/**
 	 * Adds a converter function to the conversion handler.
 	 * @param name The name to display to the user.
-	 * @param converterFunction The converter function.
+	 * @param converterFunction The converter object.
 	 */
 	public addConverter(name: string, converterFunction: FTracyConverter<string> | FTracyConverter<ReadStream>) {
 		this.converters[name] = converterFunction;
+	}
+
+	/**
+	 * Get the converter object.
+	 * @param name The display name of the converter.
+	 * @returns The converter object.
+	 */
+	public getConverter(name: string) {
+		return this.converters[name];
 	}
 
 	/**

--- a/src/converterPanel.ts
+++ b/src/converterPanel.ts
@@ -2,7 +2,7 @@ import vscode from 'vscode';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { SCHEME, TRACY_EDITOR } from './constants';
-import { DEFAULT_COMPARATOR, multiTracyCombiner, NEW_CONVERTERS } from './converters';
+import { DEFAULT_COMPARATOR, multiTracyCombiner, CONVERTERS } from './converters';
 import { Ext2WebMessage, Web2ExtMessage } from './communicationProtocol';
 import { getAnswers, getDateStringTimezone } from './utility';
 import { FileSizeEstimator, MediumFileSizeEstimator } from './fileSizeEstimator';
@@ -43,10 +43,10 @@ export class ConverterPanel {
 		this._extensionUri = extensionUri;
 		this._fileSizeEstimator = new MediumFileSizeEstimator();
 		this._converter = new ConversionHandler((fileName: string) => statSync(fileName).mtimeMs);
-		this._converter.addConverter("CSV automatic", NEW_CONVERTERS.TRACY_STREAM_PAPAPARSER);
-		this._converter.addConverter("CSV standard (deprecated)", NEW_CONVERTERS.TRACY_STRING_STANDARD_CONVERTER);
-		this._converter.addConverter("XML format (unimplemented)", NEW_CONVERTERS.TRACY_XML);
-		this._converter.addConverter("Tracy JSON", NEW_CONVERTERS.TRACY_JSON_READER);
+		this._converter.addConverter("CSV automatic", CONVERTERS.TRACY_STREAM_PAPAPARSER);
+		this._converter.addConverter("CSV standard (deprecated)", CONVERTERS.TRACY_STRING_STANDARD_CONVERTER);
+		this._converter.addConverter("XML format (unimplemented)", CONVERTERS.TRACY_XML);
+		this._converter.addConverter("Tracy JSON", CONVERTERS.TRACY_JSON_READER);
 
 		// Create and show a new webview panel
 		this._panel = vscode.window.createWebviewPanel(ConverterPanel.viewType, "Tracy Reader Options", column, {

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -1,4 +1,4 @@
-import fs, { ReadStream } from 'fs';
+import fs from 'fs';
 import papa from 'papaparse';
 import vscode from 'vscode';
 import { FileMetaData, FileMetaDataOptions } from './communicationProtocol';
@@ -16,22 +16,22 @@ export const DEFAULT_COMPARATOR = (a: string, b: string) => (parseDateString(a).
 
 export type TracyData = {[s: string]: string};
 
-export type FTracyConverter<T extends string | ReadStream> = {
+export interface FTracyConverter<T> {
 	/**
 	 * Gets the metadata of the file.
-	 * @param fileName The name of the file.
+	 * @param fileData The name of the file.
 	 * @returns The metadata of the file.
 	 */
-	getMetadata: (fileName: string, options: Partial<FileMetaDataOptions>) => Promise<FileMetaData>;
+	getMetadata: (fileData: T, options: Partial<FileMetaDataOptions>) => Promise<FileMetaData>;
 
 	/**
 	 * Opens and converts the given file, only returns the rows/entries that have a time/id between the given constraints.
-	 * @param fileName The name of the file that is to be converted.
+	 * @param fileData The name of the file that is to be converted.
 	 * @param header The header that denotes the time/id of the row/entry.
 	 * @param constraints A tuple containing values used for filtering the output, they are compared using the comparator.
 	 * @returns A promise of the resulting tracy object array.
 	 */
-	getData: (fileName: string, constraints: [string, string]) => Promise<TracyData[]>;
+	getData: (fileData: T, constraints?: [string, string]) => Promise<TracyData[]>;
 
 	/**
 	 * This is an optional parameter, it should only be used when one wants to reuse one of the old converters.
@@ -68,15 +68,15 @@ const STRING_VSC_READER = async (fileName: string) => {
  * @throws A string describing the error that has occurred.
  * @returns The new metadata object.
  */
-function entryCrawler(entries: TracyData[], options: Partial<FileMetaDataOptions>, inputMetadata: FileMetaData | string): FileMetaData {
-	const metadata: FileMetaData = typeof inputMetadata === 'string' ? {
-		fileName: inputMetadata,
+function entryCrawler(entries: TracyData[], options: Partial<FileMetaDataOptions>, inputMetadata?: FileMetaData): FileMetaData {
+	const metadata: FileMetaData = inputMetadata ?? {
+		fileName: "",
 		headers: [],
 		firstDate: '',
 		lastDate: '',
 		dataSizeIndices: [],
 		termOccurrances: []
-	} : inputMetadata;
+	};
 
 	if (!metadata.headers || metadata.headers.length === 0) {
 		// This runs only the first time
@@ -116,13 +116,13 @@ function entryCrawler(entries: TracyData[], options: Partial<FileMetaDataOptions
 }
 
 const PARSER_CHUNK_SIZE = 1024; // I don't know how big we want this
-export const NEW_CONVERTERS: {[s: string]: FTracyConverter<string | ReadStream>} = {
+export const NEW_CONVERTERS: {[s: string]: FTracyConverter<string> | FTracyConverter<fs.ReadStream>} = {
 	// This is the default converter. It uses streams to convert CSV files. Better for large files.
 	TRACY_STREAM_PAPAPARSER: {
 		fileReader: STREAM_FS_READER,
-		getMetadata: function (fileName: string, options: Partial<FileMetaDataOptions>): Promise<FileMetaData> {
-			return this.fileReader(fileName).then(stream => new Promise<FileMetaData>((resolve, reject) => {
-				let metadata: FileMetaData | string = fileName;
+		getMetadata: function (stream, options: Partial<FileMetaDataOptions>): Promise<FileMetaData> {
+			return new Promise<FileMetaData>((resolve, reject) => {
+				let metadata: FileMetaData;
 
 				papa.parse<TracyData>(stream, {
 					chunkSize: PARSER_CHUNK_SIZE,
@@ -144,10 +144,10 @@ export const NEW_CONVERTERS: {[s: string]: FTracyConverter<string | ReadStream>}
 						else reject(`problem with obtaining metadata: ${metadata}`);
 					}
 				});
-			}));
+			});
 		},
-		getData: function (fileName: string, constraints: [string, string]): Promise<TracyData[]> {
-			return this.fileReader(fileName).then(stream => new Promise<TracyData[]>((resolve, reject) => {
+		getData: function (stream, constraints): Promise<TracyData[]> {
+			return new Promise<TracyData[]>((resolve, reject) => {
 				const contents: TracyData[] = [];
 				// The parser does not have a completion call, so use the stream to do so
 				papa.parse<TracyData>(stream, {
@@ -158,7 +158,9 @@ export const NEW_CONVERTERS: {[s: string]: FTracyConverter<string | ReadStream>}
 						results.data.forEach((row) => {
 							const timestampString = row[headerField];
 							// If within the timestamp constraints, then add it to the contents
-							if (DEFAULT_COMPARATOR(constraints[0], timestampString) <= 0 && DEFAULT_COMPARATOR(timestampString, constraints[1]) <= 0) {
+							if (!constraints 
+								|| DEFAULT_COMPARATOR(constraints[0], timestampString) <= 0 
+								&& DEFAULT_COMPARATOR(timestampString, constraints[1]) <= 0) {
 								contents.push(row);
 							}
 						})
@@ -170,56 +172,52 @@ export const NEW_CONVERTERS: {[s: string]: FTracyConverter<string | ReadStream>}
 						resolve(contents);
 					}
 				});
-			}));
+			});
 		}
-	},
+	} as FTracyConverter<fs.ReadStream>,
 
 	// For backwards compatability. This is an example of how the old parser/converter implementations can be reused.
 	TRACY_STRING_STANDARD_CONVERTER: {
 		oldConverter: standardConvert, // Just put the old version here
 		fileReader: STRING_VSC_READER,
-		getMetadata: function (fileName: string, options): Promise<FileMetaData> {
-			return this.fileReader(fileName).then(content => {
-				const data = this.oldConverter!(content as string);
-				if (data.length === 0) return Promise.reject("Converter could not convert.");
+		getMetadata: async function (fileData, options): Promise<FileMetaData> {
+			const data = this.oldConverter!(fileData as string);
+			if (data.length === 0) return Promise.reject("Converter could not convert.");
 
-				// Crawl through data
-				return entryCrawler(data, options, fileName);
-			});
+			// Crawl through data
+			return entryCrawler(data, options);
 		},
-		getData: function (fileName: string, constraints: [string, string]): Promise<TracyData[]> {
-			return this.fileReader(fileName).then(content => { // open using vscode
-				const data = this.oldConverter!(content as string); // convert with the legacy converter
-				if (data.length === 0) return Promise.reject("Converter could not convert");
-				const timeHeader = Object.keys(data[0])[TIMESTAMP_HEADER_INDEX];
-				// filter the data, remove the entries not within the set time range
-				return data.filter(entry => (DEFAULT_COMPARATOR(constraints[0], entry[timeHeader]) <= 0 && DEFAULT_COMPARATOR(entry[timeHeader], constraints[1]) <= 0));
-			});
+		getData: async function (fileData, constraints): Promise<TracyData[]> {
+			const data = this.oldConverter!(fileData as string); // convert with the legacy converter
+			if (data.length === 0) return Promise.reject("Converter could not convert");
+			const timeHeader = Object.keys(data[0])[TIMESTAMP_HEADER_INDEX];
+			// filter the data, remove the entries not within the set time range
+			return data.filter(entry => (!constraints 
+				|| DEFAULT_COMPARATOR(constraints[0], entry[timeHeader]) <= 0 
+				&& DEFAULT_COMPARATOR(entry[timeHeader], constraints[1]) <= 0));
 		}
-	},
+	} as FTracyConverter<string>,
 
 	TRACY_JSON_READER: {
 		fileReader: STRING_FS_READER,
-		getMetadata: function (fileName: string, options): Promise<FileMetaData> {
-			return this.fileReader(fileName).then(content => {
-				// Read the json file
-				const data = JSON.parse(content as string) as TracyData[];
-				if (data.length === 0) return Promise.reject("Converter could not convert.");
+		getMetadata: async function (fileData, options): Promise<FileMetaData> {
+			// Read the json file
+			const data = JSON.parse(fileData as string) as TracyData[];
+			if (data.length === 0) return Promise.reject("Converter could not convert.");
 
-				// Crawl through data
-				return entryCrawler(data, options, fileName);
-			});
+			// Crawl through data
+			return entryCrawler(data, options);
 		},
-		getData: function (fileName: string, constraints: [string, string]): Promise<TracyData[]> {
-			return this.fileReader(fileName).then(content => {
-				const data = JSON.parse(content as string) as TracyData[];
-				if (data.length === 0) return Promise.reject("Converter could not convert");
-				const timeHeader = Object.keys(data[0])[TIMESTAMP_HEADER_INDEX];
-				// filter the data, remove the entries not within the set time range
-				return data.filter(entry => (DEFAULT_COMPARATOR(constraints[0], entry[timeHeader]) <= 0 && DEFAULT_COMPARATOR(entry[timeHeader], constraints[1]) <= 0));
-			});
+		getData: async function (fileData, constraints): Promise<TracyData[]> {
+			const data = JSON.parse(fileData as string) as TracyData[];
+			if (data.length === 0) return Promise.reject("Converter could not convert");
+			const timeHeader = Object.keys(data[0])[TIMESTAMP_HEADER_INDEX];
+			// filter the data, remove the entries not within the set time range
+			return data.filter(entry => (!constraints
+				|| DEFAULT_COMPARATOR(constraints[0], entry[timeHeader]) <= 0
+				&& DEFAULT_COMPARATOR(entry[timeHeader], constraints[1]) <= 0));
 		}
-	},
+	} as FTracyConverter<string>,
 
 	TRACY_XML: {
 		fileReader: STRING_FS_READER,
@@ -229,7 +227,7 @@ export const NEW_CONVERTERS: {[s: string]: FTracyConverter<string | ReadStream>}
 		getData: function (): Promise<TracyData[]> {
 			throw new Error('Function not implemented.');
 		}
-	},
+	} as FTracyConverter<string>,
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,41 +30,19 @@ export function activate(context: vscode.ExtensionContext) {
 		if (editor) {
 			const choice = await vscode.window.showQuickPick(Object.keys(converters.CONVERTERS));
 			if (choice) {
-				const converter = converters.CONVERTERS[choice];
-				const uri = vscode.Uri.parse(`${SCHEME}:${editor.document.fileName.replace(".csv", ".tracy.json")}`);
-				if (choice === "Define custom converter") {
-					// Define-your-own / DIY csv converter
-					getCSVInfo(editor.document).then(async csvInfo => {
-						const converted = converter(editor.document.getText(), converters.COL_DELIMITERS[csvInfo[1]], converters.ROW_DELIMITERS[csvInfo[0]], csvInfo[2]); // this gets the document from that is currently open in the editor
-						// what I want is to be able to select multiple files not in the editor
-						contents[uri.path] = JSON.stringify(converted);
-						await vscode.commands.executeCommand('vscode.openWith', uri, TRACY_EDITOR);
-					});					
-				} else {
-					const converted = converter(editor.document.getText());
+				const uri = vscode.Uri.parse(`${SCHEME}:${editor.document.fileName.replace(/\.csv|\.txt/gi, ".tracy.json")}`);
+				try {
+					const converter = converters.CONVERTERS[choice];
+					const converted = await converter.fileReader(editor.document.uri.fsPath).then(data => converter.getData(data as never));
 					contents[uri.path] = JSON.stringify(converted);
-					await vscode.commands.executeCommand('vscode.openWith', uri, TRACY_EDITOR);
+				} catch (e) {
+					console.log(e);
 				}
-				//await vscode.commands.executeCommand('vscode.openWith', uri, TRACY_EDITOR);
+				await vscode.commands.executeCommand('vscode.openWith', uri, TRACY_EDITOR);
 			}
 		}
 	});
 
 	context.subscriptions.push(multiConverterCommand);
 	context.subscriptions.push(disposable);
-}
-
-/**
- * Asks the users the documents delimiters and which header to sort by if any.
- * @param doc The document to get the headers from
- * @returns a tuple of the row delimiter, column delimiter, and the column/header to sort by
- */
-async function getCSVInfo(doc: vscode.TextDocument) : Promise<[string, string, string | undefined]> { // Use this function to ask the user what format the csv file is in
-	const rowDelimiter = await vscode.window.showQuickPick(Object.keys(converters.ROW_DELIMITERS), {title: "What symbol divides the rows?"});
-	if (!rowDelimiter) return Promise.reject(); // user has cancelled the operation
-	const colDelimiter = await vscode.window.showQuickPick(Object.keys(converters.COL_DELIMITERS), {title: "What symbol divides the columns?"});
-	if (!colDelimiter) return Promise.reject(); // user has cancelled the operation
-	const headers = doc.getText().slice(0, doc.getText().indexOf(converters.ROW_DELIMITERS[rowDelimiter])).split(converters.COL_DELIMITERS[colDelimiter]);
-	const sortColumn = await vscode.window.showQuickPick(headers, { title: "Sort by which column? (Esc for no sorting)" }); // undefined means no sorting
-	return [rowDelimiter, colDelimiter, sortColumn];
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,14 +39,15 @@ export function activate(context: vscode.ExtensionContext) {
 			const choice = await vscode.window.showQuickPick(conversionHandler.getConvertersList());
 			if (choice) {
 				const uri = vscode.Uri.parse(`${SCHEME}:${editor.document.fileName.replace(/\.csv|\.txt/gi, ".tracy.json")}`);
-				try {
-					const converter = conversionHandler.getConverter(choice);
-					const converted = await converter.fileReader(editor.document.uri.fsPath).then(data => converter.getData(data as never));
+				const converter = conversionHandler.getConverter(choice);
+				converter.fileReader(editor.document.uri.fsPath).then(data => converter.getData(data as never)).then(converted => {
 					contents[uri.path] = JSON.stringify(converted);
-				} catch (e) {
-					console.log(e);
-				}
-				await vscode.commands.executeCommand('vscode.openWith', uri, TRACY_EDITOR);
+					vscode.commands.executeCommand('vscode.openWith', uri, TRACY_EDITOR);
+				}).catch((reason: Error | string) => {
+					console.log("Reason: " + reason);
+					vscode.window.showErrorMessage(reason.toString());
+				});					
+
 			}
 		} else {
 			vscode.window.showErrorMessage("Current document is not open in a text editor.");

--- a/src/test/converter.test.ts
+++ b/src/test/converter.test.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import Sinon from "sinon";
 import { afterEach, describe, it } from "mocha";
-import { FTracyConverter, NEW_CONVERTERS, TracyData, multiTracyCombiner } from '../converters';
+import { FTracyConverter, CONVERTERS, TracyData, multiTracyCombiner } from '../converters';
 import { FileMetaData, FileMetaDataOptions } from '../communicationProtocol';
 import { ReadStream } from "fs";
 import { cloneDeep } from "lodash";
@@ -45,8 +45,8 @@ const metadataOptions: [string, FileMetaDataOptions, number][] = [
 describe("CSV converters", () => {
     const csvConverters: [string, FTracyConverter<string> | FTracyConverter<ReadStream>, number[]][] = [
         // Name, Converter, Should Pass
-        ["Papa parser converter", NEW_CONVERTERS.TRACY_STREAM_PAPAPARSER, [0, 1, 2]],
-        ["deprecated standard converter", NEW_CONVERTERS.TRACY_STRING_STANDARD_CONVERTER, [0]],
+        ["Papa parser converter", CONVERTERS.TRACY_STREAM_PAPAPARSER, [0, 1, 2]],
+        ["deprecated standard converter", CONVERTERS.TRACY_STRING_STANDARD_CONVERTER, [0]],
     ];
 
     csvConverters.forEach(([name, converter, canPassTestIndices]) => {

--- a/src/test/converter.test.ts
+++ b/src/test/converter.test.ts
@@ -43,7 +43,7 @@ const metadataOptions: [string, FileMetaDataOptions, number][] = [
 
 // Test the implemented converters
 describe("CSV converters", () => {
-    const csvConverters: [string, FTracyConverter<string | ReadStream>, number[]][] = [
+    const csvConverters: [string, FTracyConverter<string> | FTracyConverter<ReadStream>, number[]][] = [
         // Name, Converter, Should Pass
         ["Papa parser converter", NEW_CONVERTERS.TRACY_STREAM_PAPAPARSER, [0, 1, 2]],
         ["deprecated standard converter", NEW_CONVERTERS.TRACY_STRING_STANDARD_CONVERTER, [0]],
@@ -56,11 +56,11 @@ describe("CSV converters", () => {
                     Sinon.restore();
                 });
                 it("should bubble up thrown file read errors", (done) => {
-                    async function fileReadThrow(): Promise<string | ReadStream> {
+                    async function fileReadThrow(): Promise<string> {
                         throw "File Read error";
                     }
                     Sinon.replace(converter, "fileReader", fileReadThrow);
-                    converter.getMetadata("test", metadataOptions[0][1]).then(() => {
+                    converter.fileReader("test").then(fileData => converter.getMetadata(fileData as never, metadataOptions[0][1])).then(() => {
                         // Should not happen
                         assert.fail("Should not return any metadata for a thrown file read error");
                     }).catch((reason) => {
@@ -79,11 +79,11 @@ describe("CSV converters", () => {
                         // Should be able to pass
                         it("should work with " + fileName + " files", (done) => {
                             Sinon.replace(converter, "fileReader", Sinon.fake.resolves(inputData));
-                            converter.getMetadata("test", metadataOptions[0][1]).then(fmd => {
+                            converter.fileReader("test").then(fileData => converter.getMetadata(fileData as never, metadataOptions[0][1])).then(fmd => {
                                 assert.deepEqual(fmd, metaData);
                             }).finally(done);
                         });
-                        if (onlyOnce) {
+                        if (onlyOnce) { // Only need to test the following once per correct data input
                             onlyOnce = false;
                             // Test all the options
                             metadataOptions.slice(1).forEach((v) => {
@@ -91,7 +91,7 @@ describe("CSV converters", () => {
                                     Sinon.replace(converter, "fileReader", Sinon.fake.resolves(inputData));
                                     const editedMetaData = cloneDeep(metaData)!;
                                     editedMetaData.termOccurrances = [[v[1].terms[0][0], v[2]]];
-                                    converter.getMetadata("test", v[1]).then(fmd => {
+                                    converter.fileReader("test").then(fileData => converter.getMetadata(fileData as never, v[1])).then(fmd => {
                                         assert.deepEqual(fmd, editedMetaData);
                                     }).finally(done);
                                 });
@@ -101,7 +101,7 @@ describe("CSV converters", () => {
                         // Should not pass
                         it("should not work with " + fileName + " files", (done) => {
                             Sinon.replace(converter, "fileReader", Sinon.fake.resolves(inputData));
-                            converter.getMetadata("test", metadataOptions[0][1]).then(() => {
+                            converter.fileReader("test").then(fileData => converter.getMetadata(fileData as never, metadataOptions[0][1])).then(() => {
                                 // Should not happen, fail
                                 assert.fail("Should not return any metadata for an unparsable file");
                             }).catch((reason) => {
@@ -124,7 +124,7 @@ describe("CSV converters", () => {
                         const tracyData = testTracyData.at(tracyDataIndex);
                         it("should work with " + fileName + " files", (done) => {
                             Sinon.replace(converter, "fileReader", Sinon.fake.resolves(inputData));
-                            converter.getData("test", [metaData!.firstDate, metaData!.lastDate]).then(fmd => {
+                            converter.fileReader("test").then(fileData => converter.getData(fileData as never, [metaData!.firstDate, metaData!.lastDate])).then(fmd => {
                                 assert.deepEqual(fmd, tracyData);
                             }).finally(done);
                         });
@@ -132,7 +132,7 @@ describe("CSV converters", () => {
                         // Should not pass
                         it("should not work with " + fileName + " files", (done) => {
                             Sinon.replace(converter, "fileReader", Sinon.fake.resolves(inputData));
-                            converter.getData("test", ["doesn't matter", "doesn't matter"]).then(() => {
+                            converter.fileReader("test").then(fileData => converter.getData(fileData as never, ["doesn't matter", "doesn't matter"])).then(() => {
                                 // Should not happen, fail
                                 assert.fail("Should not return any tracyData for an unparsable file");
                             }).catch((reason) => {


### PR DESCRIPTION
The command "Open current document with Tracy" now only shows the updated parsers/converters.